### PR TITLE
Contra / Gryzor improvements

### DIFF
--- a/src/drivers/contra.c
+++ b/src/drivers/contra.c
@@ -63,17 +63,59 @@ static WRITE_HANDLER( cpu_sound_command_w )
 	soundlatch_w(offset,data);
 }
 
+UINT32 math_regs[6];
+UINT16 multiply_result;
+UINT16 divide_quotient;
+UINT16 divide_remainder;
 
+
+READ_HANDLER(contra_k007452_r)
+{
+	switch (offset & 7)
+	{
+		case 0: return multiply_result & 0xff;
+		case 1: return (multiply_result >> 8) & 0xff;
+		case 2: return divide_remainder & 0xff;
+		case 3: return (divide_remainder >> 8) & 0xff;
+		case 4:	return divide_quotient & 0xff;
+		case 5: return (divide_quotient >> 8) & 0xff;
+		default: return 0;
+	}
+}
+
+
+WRITE_HANDLER(contra_k007452_w)
+{
+	if (offset < 6) math_regs[offset] = data;
+
+	if (offset == 1)
+	{
+		// Starts multiplication process
+		multiply_result = math_regs[0] * math_regs[1];
+	}
+	else if (offset == 5)
+	{
+		// Starts division process
+		UINT16 dividend = (math_regs[4]<<8) + math_regs[5];
+		UINT16 divisor = (math_regs[2]<<8) + math_regs[3];
+		if (!divisor) {
+			divide_quotient = 0xffff;
+			divide_remainder = 0x0000;
+		} else {
+			divide_quotient = dividend / divisor;
+			divide_remainder = dividend % divisor;
+		}
+	}
+}
 
 static MEMORY_READ_START( readmem )
+        { 0x0008, 0x000f, contra_k007452_r },
 	{ 0x0010, 0x0010, input_port_0_r },		/* IN0 */
 	{ 0x0011, 0x0011, input_port_1_r },		/* IN1 */
 	{ 0x0012, 0x0012, input_port_2_r },		/* IN2 */
-
 	{ 0x0014, 0x0014, input_port_3_r },		/* DIPSW1 */
 	{ 0x0015, 0x0015, input_port_4_r },		/* DIPSW2 */
 	{ 0x0016, 0x0016, input_port_5_r },		/* DIPSW3 */
-
 	{ 0x0c00, 0x0cff, MRA_RAM },
 	{ 0x1000, 0x5fff, MRA_RAM },
 	{ 0x6000, 0x7fff, MRA_BANK1 },
@@ -82,6 +124,7 @@ MEMORY_END
 
 static MEMORY_WRITE_START( writemem )
 	{ 0x0000, 0x0007, contra_K007121_ctrl_0_w },
+	{ 0x0008, 0x000f, contra_k007452_w },
 	{ 0x0018, 0x0018, contra_coin_counter_w },
 	{ 0x001a, 0x001a, contra_sh_irqtrigger_w },
 	{ 0x001c, 0x001c, cpu_sound_command_w },


### PR DESCRIPTION
furrtek Added Konami 007452 multiplier/divider fixes rolling mines trajectories in contra

Rather than add a whole new device im just hooking it directly into the Contra driver for this core
Combat School Flak Attack and WACLeMans also use this but for now im focusing on Contra as
the game improvements are known

Whereas with the others the benefits over the original simulations are not as yet known if indeed there are any.