### PR TITLE
Fix invincibility flashing and broken gfx see decription

### DIFF
--- a/src/drivers/m92.c
+++ b/src/drivers/m92.c
@@ -2275,7 +2275,7 @@ static DRIVER_INIT( rtypeleo )
 	install_mem_read_handler(0, 0xe0032, 0xe0033, rtypeleo_cycle_r);
 	init_m92(rtypeleo_decryption_table);
 	m92_irq_vectorbase=0x20;
-	m92_game_kludge=1;
+	m92_game_kludge=3;
 }
 
 static DRIVER_INIT( rtypelej )
@@ -2283,7 +2283,7 @@ static DRIVER_INIT( rtypelej )
 	install_mem_read_handler(0, 0xe0032, 0xe0033, rtypelej_cycle_r);
 	init_m92(rtypeleo_decryption_table);
 	m92_irq_vectorbase=0x20;
-	m92_game_kludge=1;
+	m92_game_kludge=3;
 }
 
 static DRIVER_INIT( majtitl2 )


### PR DESCRIPTION
There is a gfx speedup present in the video code which actually breaks the backgrounds on level 4 and the colour cycling
effects which determine the hue of some enemy bullets and certain background structures for example lazer grid on level 1
all throughout the game in R-Type Leo.

Disabling the gfx speedup fixes this but there is a performance penalty by doing so but i never noticed it really on the xbox
the switch is more powerfull so it shouldn't be an issue the cpu speedups are still present and active, i've also disabled
the pallette banking as per what they did in latest MAME to fix the invincibility flashing on the ship after you die.